### PR TITLE
Fixed the blank websites to block UI

### DIFF
--- a/my-extension/src/components/Restrict.tsx
+++ b/my-extension/src/components/Restrict.tsx
@@ -30,6 +30,7 @@ function Restrict() {
       <div
         style={{
           display: "flex",
+          flexDirection:"column", //added flex direction column because i moved the random message inside this div
           justifyContent: "center",
           alignItems: "center",
         }}
@@ -37,12 +38,12 @@ function Restrict() {
         <img
           src="https://cdn.dribbble.com/users/285475/screenshots/2083086/dribbble_1.gif"
           alt="restrict gif"
+          style={{maxHeight:"500px"}} //set max height of gif to 500px so it doesn't push the random message out of the view height
         />
-      </div>
-
-      <h3 style={{ textAlign: "center", fontSize: "30px", color: "black" }}>
+        <h3 style={{ textAlign: "center", fontSize: "30px", color: "black" }}>
         {randomMessage}
-      </h3>
+        </h3> {/* moved the h3 tag inside the div that contains the image to ensure that the random message is always underneath the gif */}
+      </div>
     </div>
   );
 }

--- a/my-extension/src/components/Restrict.tsx
+++ b/my-extension/src/components/Restrict.tsx
@@ -30,7 +30,6 @@ function Restrict() {
       <div
         style={{
           display: "flex",
-          flexDirection:"column", //added flex direction column because i moved the random message inside this div
           justifyContent: "center",
           alignItems: "center",
         }}
@@ -38,12 +37,12 @@ function Restrict() {
         <img
           src="https://cdn.dribbble.com/users/285475/screenshots/2083086/dribbble_1.gif"
           alt="restrict gif"
-          style={{maxHeight:"500px"}} //set max height of gif to 500px so it doesn't push the random message out of the view height
         />
-        <h3 style={{ textAlign: "center", fontSize: "30px", color: "black" }}>
-        {randomMessage}
-        </h3> {/* moved the h3 tag inside the div that contains the image to ensure that the random message is always underneath the gif */}
       </div>
+
+      <h3 style={{ textAlign: "center", fontSize: "30px", color: "black" }}>
+        {randomMessage}
+      </h3>
     </div>
   );
 }

--- a/my-extension/src/components/WebsiteEditPage.tsx
+++ b/my-extension/src/components/WebsiteEditPage.tsx
@@ -46,7 +46,7 @@ export default function WebsiteEditPage() {
       setHasOpened(true); // This marks the initial setup as done
       }
       }
-      }, []); //this was different from the code in the deployment so copied the deployed code back which caused the edit websites to block to start working again
+      }, []);
 
     useEffect(() => {
       localStorage.setItem('hasOpened', JSON.stringify(true));

--- a/my-extension/src/components/WebsiteEditPage.tsx
+++ b/my-extension/src/components/WebsiteEditPage.tsx
@@ -17,23 +17,36 @@ export default function WebsiteEditPage() {
     const [newWebsiteName, setNewWebsiteName] = useState("")
     const [showAlreadyBlockedWebsites, setShowAlreadyBlockedWebsites] = useState<boolean>(true) // websites that are already blocked (eg. reddit, insta etc.)
     const [showCustomBlockedWebsites, setShowCustomBlockedWebsites] = useState<boolean>(true) // websites that are 
-    const [alreadyBlockedWebsitesSet, setSlreadyBlockedWebsitesSet] = useState([])
+    const [alreadyBlockedWebsitesSet, setSlreadyBlockedWebsitesSet] = useState<string[]>([]) // added a type for the already blocked websites state variable
     const [hasOpened, setHasOpened] = useState<boolean | null>(JSON.parse(localStorage.getItem('hasOpened')!) ? JSON.parse(localStorage.getItem('hasOpened')!) : false)
 
     console.log(hasOpened)
 
     useEffect(() => {
-      // Load saved list from local storage or use the hardcoded list if none is found
-      const savedItems = JSON.parse(localStorage.getItem('alreadyBlockedWebsites')!);
-      if (savedItems && savedItems.length > 0) {
-        setSlreadyBlockedWebsitesSet(savedItems);
-      } else if(savedItems.length === 0 && hasOpened === false) {
-        setSlreadyBlockedWebsitesSet(alreadyBlockedWebsites as any);
-        setHasOpened(true)
-      }else if(savedItems.length === 0 && hasOpened === true) {
-        setSlreadyBlockedWebsitesSet([])
+      // Attempt to load the list from local storage
+      let savedItems;
+      try {
+      const item = localStorage.getItem("alreadyBlockedWebsites");
+      savedItems = item ? JSON.parse(item) : null;
+      } catch (error) {
+      console.error("Error parsing alreadyBlockedWebsites from localStorage:", error);
+      savedItems = null;
       }
-    }, []);
+      if (savedItems && savedItems.length > 0) {
+      // If savedItems exists and has items, use it
+      setSlreadyBlockedWebsitesSet(savedItems);
+      } else {
+      // If savedItems is null, empty, or parsing failed
+      if (hasOpened) {
+      // If the app has been opened before, set to an empty array
+      setSlreadyBlockedWebsitesSet([]);
+      } else {
+      // If the app has not been opened before, use the hardcoded list and mark as opened
+      setSlreadyBlockedWebsitesSet(alreadyBlockedWebsites); // Assuming 'alreadyBlockedWebsites' is an array
+      setHasOpened(true); // This marks the initial setup as done
+      }
+      }
+      }, []); //this was different from the code in the deployment so copied the deployed code back which caused the edit websites to block to start working again
 
     useEffect(() => {
       localStorage.setItem('hasOpened', JSON.stringify(true));

--- a/my-extension/src/content/index.tsx
+++ b/my-extension/src/content/index.tsx
@@ -31,10 +31,12 @@ chrome.storage.local.get(["websitesToBlock"], function (result) {
     currentWebsite.toLowerCase().includes(item.toLowerCase())
   );
 
-  if (restricExist) {
+  if (restricExist && !document.getElementById('restrict-overlay')) {
     const div = document.createElement("div");
+    div.id = 'restrict-overlay'
     document.body.style.overflow = "hidden";
     document.body.appendChild(div);
     ReactDOM.render(<Restrict />, div);
   }
 });
+//content script was running multiple times so added code to check if the restrict component is already rendered before adding a new one 

--- a/my-extension/src/content/index.tsx
+++ b/my-extension/src/content/index.tsx
@@ -31,12 +31,10 @@ chrome.storage.local.get(["websitesToBlock"], function (result) {
     currentWebsite.toLowerCase().includes(item.toLowerCase())
   );
 
-  if (restricExist && !document.getElementById('restrict-overlay')) {
+  if (restricExist) {
     const div = document.createElement("div");
-    div.id = 'restrict-overlay'
     document.body.style.overflow = "hidden";
     document.body.appendChild(div);
     ReactDOM.render(<Restrict />, div);
   }
 });
-//content script was running multiple times so added code to check if the restrict component is already rendered before adding a new one 

--- a/my-extension/src/content/index.tsx
+++ b/my-extension/src/content/index.tsx
@@ -1,7 +1,11 @@
 import ReactDOM from "react-dom";
 import Restrict from "../components/Restrict";
 
-export const alreadyBlockedWebsites = [
+export interface defaultBlockedSites {
+  alreadyBlockedWebsites:string[]
+}
+// added an interface for the already blocked sites
+export const alreadyBlockedWebsites:defaultBlockedSites['alreadyBlockedWebsites'] = [
   "reddit",
   "facebook",
   "twitter",


### PR DESCRIPTION
When cloning the project on local machine, i noticed that the UI for editing the blocked websites was blank. This was because the some part of the code in the repository was different from the deployed code. This meant that the deployed version worked fine while the code in the repo was not working making it difficult to contribute.
I fixed it by replacing replacing those lines of code with the deployed code and that got it working again.
I also added a type for the default blocked sites to ensure type safety

Closes #29 